### PR TITLE
Fix broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,6 @@ In the above example, the `CTP_POST_BODY` variable contains the following fields
          PLN as fallback, we use turn `EUR` into `PLN`.
      > - If the fallback is an empty string, **no data is shared with Talon.One** if the currency doesn't match.
 
-   - `PAY_WITH_POINTS_ATTRIBUTE_NAME`: The name of the attribute to use to pay with loyalty points. Example:
-     `PayWithPoints`.
-
    - `ONLY_VERIFIED_PROFILES`: commercetools will send only profiles with a verified email address.
 
    - `SKU_TYPE`: Determines how the SKU from Talon.One is converted to `SKU_TYPE` in commercetools. Possible values:


### PR DESCRIPTION
### This Pull Request is a

- [ ] New feature
- [ ] Bug fix
- [x] Documentation change
- [ ] Performance optimization
- [ ] Code refactoring
- [ ] Other: please add a description

### Problem 

 - A broken link to the supported commercetools fields doc in the README file
 - One env variable is duplicate in the list

### Solution 

 - [x] Fix the reference of the link
 - [x] Remove the duplicate env variable
