### PR TITLE
fix: Discounts with same names are not applied correctly

### DIFF
--- a/src/api-extension/mocks/actions/update-cart-actions.json
+++ b/src/api-extension/mocks/actions/update-cart-actions.json
@@ -70,7 +70,7 @@
       "name": {
         "en": "10% off"
       },
-      "slug": "10percent-off",
+      "slug": "10percent-off-0",
       "taxCategory": {
         "id": "3b52cdd8-c767-4c98-923f-a269e01a6ff2",
         "typeId": "tax-category"
@@ -95,7 +95,7 @@
       "name": {
         "en": "5% off"
       },
-      "slug": "5percent-off",
+      "slug": "5percent-off-1",
       "taxCategory": {
         "id": "3b52cdd8-c767-4c98-923f-a269e01a6ff2",
         "typeId": "tax-category"
@@ -166,7 +166,7 @@
       "name": {
         "en": "10% off"
       },
-      "slug": "10percent-off-Cool-Summer!",
+      "slug": "10percent-off-Cool-Summer!-2",
       "taxCategory": {
         "id": "3b52cdd8-c767-4c98-923f-a269e01a6ff2",
         "typeId": "tax-category"

--- a/src/api-extension/mocks/commercetools/update-cart-event.json
+++ b/src/api-extension/mocks/commercetools/update-cart-event.json
@@ -2194,7 +2194,7 @@
             "centAmount": -13950,
             "fractionDigits": 2
           },
-          "slug": "10percent-off",
+          "slug": "10percent-off-0",
           "quantity": 1,
           "discountedPricePerQuantity": [],
           "taxCategory": {
@@ -2259,7 +2259,7 @@
             "centAmount": -6975,
             "fractionDigits": 2
           },
-          "slug": "5percent-off",
+          "slug": "5percent-off-1",
           "quantity": 1,
           "discountedPricePerQuantity": [],
           "taxCategory": {

--- a/src/api-extension/models/cart-action-factory.js
+++ b/src/api-extension/models/cart-action-factory.js
@@ -93,6 +93,8 @@ class CartActionFactory {
 
     this._customType = new SetCustomTypeBuilder(CartActionFactory.getInitialFields(cart));
     this._customType.cartType();
+
+    this._slugIndex = 0;
   }
 
   /**
@@ -217,6 +219,8 @@ class CartActionFactory {
     if (triggeredByCoupon) {
       slugName = slugName.concat('-', triggeredByCoupon);
     }
+
+    slugName += `-${this._slugIndex++}`;
 
     builder
       .name(this._lang, effect.props.name)


### PR DESCRIPTION
### This Pull Request is a

- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Performance optimization
- [ ] Code refactoring
- [ ] Other: please add a description

### Description

When separate effects apply different discounts using the same name (in the same campaign or otherwise) - the disambiguation between the names fails to apply both discounts.

### Solution 

When processing the effects, adding the index of the discount to the discount's slug to make that slug unique, combining both the name of the discount and its ordinal index in the whole effects processing array
